### PR TITLE
Add "re-origin" support to Manage Axes plugin

### DIFF
--- a/ManageAxes.js
+++ b/ManageAxes.js
@@ -34,10 +34,10 @@ ManageAxes.initializeUI = async function()
     contentContainer.appendChild(document.createElement('p'));
 
     // create the subsection for the "re-origin" command which
-    // moves all geometry in this history to the world origin, then transforms all instances in the reverse
+    // moves all geometry in this history to the world origin, then inversely transforms all instances of this history
     contentContainer.appendChild(new FormIt.PluginUI.HeaderModule('Re-Origin', 'Set the origin of the current editing history (group) to the bottom centroid of all geometry.').element);
 
-    // create the button for reset axes
+    // create the button for the "re-origin" command
     contentContainer.appendChild(new FormIt.PluginUI.ButtonWithInfoToggleModule('Re-Origin Current Context', "Moves all geometry in the current editing history (group) to the world origin, then applies the reverse transform to all instances of this history (group). <br><br>Helps fix numeric noise issues caused by working too far from the world origin. <br><br>Note that this only works when editing a group, and this action will affect all instances of this history (group).", ManageAxes.reOrigin).element);
 
     // separator and space
@@ -172,7 +172,7 @@ ManageAxes.resetAxes = async function()
     await WSM.APISetLocalCoordinateSystem(nHistoryID, defaultLCS);
 }
 
-// moves all geometry in the current editing history to the world origin, then applies the reverse transform to all instances
+// moves all geometry in the current editing history to the world origin, then applies the inverse transform to all instances
 ManageAxes.reOrigin = async () => {
     // get the current editing group instance path and history ID
     const editingPath = await FormIt.GroupEdit.GetInContextEditingPath();

--- a/ManageAxes.js
+++ b/ManageAxes.js
@@ -33,7 +33,8 @@ ManageAxes.initializeUI = async function()
     contentContainer.appendChild(document.createElement('hr'));
     contentContainer.appendChild(document.createElement('p'));
 
-    // create the subsection for re-origining: moving all geometry in this history to the world origin, then transforming the instance in the reverse
+    // create the subsection for re-origining: 
+    // moves all geometry in this history to the world origin, then transforms all instances in the reverse
     contentContainer.appendChild(new FormIt.PluginUI.HeaderModule('Re-Origin', 'Set the origin of the current editing history (group) to the bottom centroid of all geometry.').element);
 
     // create the button for reset axes

--- a/ManageAxes.js
+++ b/ManageAxes.js
@@ -5,8 +5,6 @@ if (typeof ManageAxes == 'undefined')
 
 /*** web/UI code - runs natively in the plugin process ***/
 
-// IDs of input elements that need to be referenced or updated
-
 ManageAxes.initializeUI = async function()
 {
     // create an overall container for all objects that comprise the "content" of the plugin
@@ -29,6 +27,17 @@ ManageAxes.initializeUI = async function()
 
     // create the button to set the LCS on the selected face
     contentContainer.appendChild(new FormIt.PluginUI.Button('Align Workplane with Face', ManageAxes.setLCSOnSelectedFace).element);
+
+    // separator and space
+    contentContainer.appendChild(document.createElement('p'));
+    contentContainer.appendChild(document.createElement('hr'));
+    contentContainer.appendChild(document.createElement('p'));
+
+    // create the subsection for re-origining: moving geometry back to the world origin, then transforming the instance to where the geometry was
+    contentContainer.appendChild(new FormIt.PluginUI.HeaderModule('Re-Origin Current Context', 'Set the origin of the current editing history to the bottom centroid of all geometry.').element);
+
+    // create the button for reset axes
+    contentContainer.appendChild(new FormIt.PluginUI.ButtonWithInfoToggleModule('Re-Origin Current Context', "Moves all geometry in the current editing context (Group) to the origin, then applies the reverse transform to the instance. Helps fix numeric noise issues caused by working too far from the world origin. Note that this only works when editing a Group.", () => {}).element);
 
     // separator and space
     contentContainer.appendChild(document.createElement('p'));

--- a/ManageAxes.js
+++ b/ManageAxes.js
@@ -189,7 +189,7 @@ ManageAxes.reOrigin = async () => {
     await FormIt.UndoManagement.BeginState();
 
     // get the bounding box of the editing history and its upper and lower bounds
-    const editingBBox = await WSM.APIGetBoxReadOnly(parentHistoryId, editingPath.ids[0].Object);
+    const editingBBox = await WSM.APIGetBoxReadOnly(editingHistoryId);
 
     // make a translation transform to the world origin
     const vec3d = await WSM.Geom.Vector3d(-(editingBBox.lower.x + editingBBox.upper.x) / 2, -(editingBBox.lower.y + editingBBox.upper.y) / 2, -editingBBox.lower.z);
@@ -216,8 +216,8 @@ ManageAxes.reOrigin = async () => {
         const instanceTransf3d = instancesOfHistory.transforms[i];
         const inverseInstanceTransf3d = await WSM.Transf3d.Invert(instanceTransf3d);
         // multiply instance transform, instance inverse transform, and geom inverse transform
-        const newTransf3dPartial = await WSM.Transf3d.Multiply(instanceTransf3d, inverseGeomTransf3d);
-        const newTransf3dFinal = await WSM.Transf3d.Multiply(newTransf3dPartial, inverseInstanceTransf3d);
+        const newTransf3dPartial = await WSM.Transf3d.Multiply(inverseGeomTransf3d, inverseInstanceTransf3d);
+        const newTransf3dFinal = await WSM.Transf3d.Multiply(instanceTransf3d, newTransf3dPartial);
         // transform the instance by the final transf3d
         await WSM.APITransformObject(instanceObjectHistoryId.History, instanceObjectHistoryId.Object, newTransf3dFinal);
     }

--- a/ManageAxes.js
+++ b/ManageAxes.js
@@ -177,7 +177,6 @@ ManageAxes.reOrigin = async () => {
     const editingPath = await FormIt.GroupEdit.GetInContextEditingPath();
     const finalEditingObjectHistoryId = await WSM.GroupInstancePath.GetTopObjectHistoryID(editingPath);
     const editingHistoryId = await FormIt.GroupEdit.GetEditingHistoryID();
-    const parentHistoryId = finalEditingObjectHistoryId.History;
 
     // this action won't be valid for the main history
     if (editingHistoryId === 0) {
@@ -225,6 +224,10 @@ ManageAxes.reOrigin = async () => {
     // reset the local origin (this gets moved along with the non-owned objects)
     const defaultLCS = await WSM.Geom.MakeRigidTransform(await WSM.Geom.Point3d(0, 0, 0), await WSM.Geom.Vector3d(1, 0, 0), await WSM.Geom.Vector3d(0, 1, 0), await WSM.Geom.Vector3d(0, 0, 1));
     await WSM.APISetLocalCoordinateSystem(editingHistoryId, defaultLCS);
+
+    // hack: end group edit mode and start again to show the updated lcs graphics
+    await FormIt.GroupEdit.EndEditInContext();
+    await FormIt.GroupEdit.SetInContextEditingPath(editingPath);
 
     await FormIt.UndoManagement.EndState("Manage Axes - Re-Origin");
 

--- a/ManageAxes.js
+++ b/ManageAxes.js
@@ -5,6 +5,9 @@ if (typeof ManageAxes == 'undefined')
 
 /*** web/UI code - runs natively in the plugin process ***/
 
+const reOriginOverrideCheckboxInputId = 'reOriginOverrideCheckbox';
+let reoriginOverrideCheckboxInput;
+
 ManageAxes.initializeUI = async function()
 {
     // create an overall container for all objects that comprise the "content" of the plugin
@@ -38,7 +41,10 @@ ManageAxes.initializeUI = async function()
     contentContainer.appendChild(new FormIt.PluginUI.HeaderModule('Re-Origin', 'Set the origin of the current editing history (group) to the bottom centroid of all geometry.').element);
 
     // create the button for the "re-origin" command
-    contentContainer.appendChild(new FormIt.PluginUI.ButtonWithInfoToggleModule('Re-Origin Current Context', "Moves all geometry in the current editing history (group) to the world origin, then applies the inverse transform to all instances of this history (group). <br><br>Helps fix numeric noise issues caused by working far from the world origin. <br><br>Note that this only works when editing a group, and this action will affect all instances of this history (group).", ManageAxes.reOrigin).element);
+    contentContainer.appendChild(new FormIt.PluginUI.ButtonWithInfoToggleModule('Re-Origin Current Context', "Moves all geometry in the current editing history (group) to the world origin, then applies the inverse transform to all instances of this history (group). <br><br>Helps fix numeric noise issues caused by working far from the world origin. <br><br>Note that this only works when editing a group, and this action will affect all instances of this history (group). <br><br>If Override Custom Origin is checked, the origin will be moved to the bottom center of the geometry, even if a custom origin had been defined in this history.", ManageAxes.reOrigin).element);''
+    contentContainer.appendChild(new FormIt.PluginUI.CheckboxModule('Override Custom Origin', 'reOriginOverrideCheckboxContainer', 'multiModuleContainer', reOriginOverrideCheckboxInputId).element);
+    reoriginOverrideCheckboxInput = document.getElementById(reOriginOverrideCheckboxInputId);
+    reoriginOverrideCheckboxInput.checked = true;
 
     // separator and space
     contentContainer.appendChild(document.createElement('p'));
@@ -54,7 +60,6 @@ ManageAxes.initializeUI = async function()
     // create the button for reset axes
     contentContainer.appendChild(new FormIt.PluginUI.ButtonWithInfoToggleModule('Reset Axes to Default', 'The standard FormIt tool to reset the local coordinate system axes to the default values.', ManageAxes.resetAxes).element);
     
-
     // create the footer
     document.body.appendChild(new FormIt.PluginUI.FooterModule().element);
 }
@@ -167,7 +172,7 @@ ManageAxes.startSetAxesTool = async function()
 ManageAxes.resetAxes = async function()
 {
     nHistoryID = await FormIt.GroupEdit.GetEditingHistoryID();
-    let defaultLCS = await WSM.Geom.MakeRigidTransform(await WSM.Geom.Point3d(0, 0, 0), await WSM.Geom.Vector3d(1, 0, 0), await WSM.Geom.Vector3d(0, 1, 0), await WSM.Geom.Vector3d(0, 0, 1));
+    let defaultLCS = await WSM.Transf3d.Transf3d();
 
     await WSM.APISetLocalCoordinateSystem(nHistoryID, defaultLCS);
 }
@@ -241,10 +246,12 @@ ManageAxes.reOrigin = async () => {
 
     await FormIt.UndoManagement.EndState("Manage Axes - Re-Origin");
 
-    // reset the local origin (this gets moved along with the non-owned objects) 
-    // so the local origin appears at the bottom center of the geometry
-    const defaultLCS = await WSM.Transf3d.Transf3d();
-    await WSM.APISetLocalCoordinateSystem(editingHistoryId, defaultLCS);
+    // if the override checkbox is checked, reset the axes
+    if (reoriginOverrideCheckboxInput.checked) {
+        // local origin was moved with the geom transform operation
+        // reset the axes so the local origin appears at the bottom center of the geometry
+        ManageAxes.resetAxes();
+    }
 
     // hack: end group edit mode and start again to force show the updated origin position
     await FormIt.GroupEdit.EndEditInContext();

--- a/ManageAxes.js
+++ b/ManageAxes.js
@@ -33,7 +33,7 @@ ManageAxes.initializeUI = async function()
     contentContainer.appendChild(document.createElement('hr'));
     contentContainer.appendChild(document.createElement('p'));
 
-    // create the subsection for re-origining: 
+    // create the subsection for the "re-origin" command which
     // moves all geometry in this history to the world origin, then transforms all instances in the reverse
     contentContainer.appendChild(new FormIt.PluginUI.HeaderModule('Re-Origin', 'Set the origin of the current editing history (group) to the bottom centroid of all geometry.').element);
 

--- a/ManageAxes.js
+++ b/ManageAxes.js
@@ -38,7 +38,7 @@ ManageAxes.initializeUI = async function()
     contentContainer.appendChild(new FormIt.PluginUI.HeaderModule('Re-Origin', 'Set the origin of the current editing history (group) to the bottom centroid of all geometry.').element);
 
     // create the button for the "re-origin" command
-    contentContainer.appendChild(new FormIt.PluginUI.ButtonWithInfoToggleModule('Re-Origin Current Context', "Moves all geometry in the current editing history (group) to the world origin, then applies the reverse transform to all instances of this history (group). <br><br>Helps fix numeric noise issues caused by working too far from the world origin. <br><br>Note that this only works when editing a group, and this action will affect all instances of this history (group).", ManageAxes.reOrigin).element);
+    contentContainer.appendChild(new FormIt.PluginUI.ButtonWithInfoToggleModule('Re-Origin Current Context', "Moves all geometry in the current editing history (group) to the world origin, then applies the inverse transform to all instances of this history (group). <br><br>Helps fix numeric noise issues caused by working far from the world origin. <br><br>Note that this only works when editing a group, and this action will affect all instances of this history (group).", ManageAxes.reOrigin).element);
 
     // separator and space
     contentContainer.appendChild(document.createElement('p'));

--- a/ManageAxes.js
+++ b/ManageAxes.js
@@ -179,7 +179,7 @@ ManageAxes.reOrigin = async () => {
     const editingHistoryId = await FormIt.GroupEdit.GetEditingHistoryID();
 
     // this action won't be valid for the main history
-    if (editingHistoryId === 0) {
+    if (editingHistoryId === await FormIt.Model.GetHistoryID ()) {
         await FormIt.UI.ShowNotification("This action requires a group to be edited. \nEdit a group and try again.", FormIt.NotificationType.Error, 0)
         return;
     }
@@ -234,7 +234,7 @@ ManageAxes.reOrigin = async () => {
 
     // reset the local origin (this gets moved along with the non-owned objects) 
     // so the local origin appears at the bottom center of the geometry
-    const defaultLCS = await WSM.Geom.MakeRigidTransform(await WSM.Geom.Point3d(0, 0, 0), await WSM.Geom.Vector3d(1, 0, 0), await WSM.Geom.Vector3d(0, 1, 0), await WSM.Geom.Vector3d(0, 0, 1));
+    const defaultLCS = await WSM.Transf3d.Transf3d();
     await WSM.APISetLocalCoordinateSystem(editingHistoryId, defaultLCS);
 
     // hack: end group edit mode and start again to force show the updated origin position

--- a/index.html
+++ b/index.html
@@ -3,10 +3,10 @@
     <!-- for testing shared files locally, use: ../../FormItExamplePlugins/SharedPluginFiles -->
     <link rel="stylesheet" type="text/css" href="https://formit3d.github.io/FormItExamplePlugins/SharedPluginFiles/FormItPluginStyling.css">
     <title>Dynamo Eyedropper</title>
-    <META NAME="Title" CONTENT="Dynamo Eyedropper">
+    <META NAME="Title" CONTENT="Manage Axes">
     <META NAME="Author" CONTENT="Autodesk FormIt">
-        <script type="text/javascript" src="https://formit3d.github.io/FormItExamplePlugins/SharedPluginFiles/FormIt.js"></script>
-        <script type="text/javascript" src="https://formit3d.github.io/FormItExamplePlugins/SharedPluginFiles/FormItInterface.js"></script>
+        <script type="text/javascript" src="https://formit3d.github.io/SharedPluginUtilities/FormIt_v22.js"></script>
+        <script type="text/javascript" src="https://formit3d.github.io/SharedPluginUtilities/v23_0/FormItInterface.js"></script>
         <script type="text/javascript" src="https://formit3d.github.io/FormItExamplePlugins/SharedPluginFiles/FormItPluginUI.js"></script>
         <script type="text/javascript" src="https://formit3d.github.io/FormItWorkflowPlugins/Utils.js"></script>
         <script type="text/javascript" src="ManageAxes.js"></script>


### PR DESCRIPTION
Adds the ability to "re-origin" an editing context: Moves all geometry in the history to the world origin, then moves all instances in the reverse direction. 

Built for a customer experiencing numeric noise issues in histories that come from Revit.

![20231203 re-origin](https://github.com/FormIt3D/ManageAxes/assets/25351609/cadef81d-f32e-4640-bf1e-329f04fc5804)

